### PR TITLE
fix: unexpected uncalled judge in recursive loop

### DIFF
--- a/call.go
+++ b/call.go
@@ -181,13 +181,14 @@ func (c *calledFrom) succs(b *ssa.BasicBlock) bool {
 		return false
 	}
 
+	var called bool
 	for _, s := range b.Succs {
-		if !c.instrs(s.Instrs) && !c.succs(s) {
-			return false
+		if c.instrs(s.Instrs) || c.succs(s) {
+			called = true
 		}
 	}
 
-	return true
+	return called
 }
 
 // CalledFrom checks whether receiver's method is called in an instruction


### PR DESCRIPTION
# Related issue 
https://github.com/gostaticanalysis/sqlrows/issues/1

# Detail
`func (c *calledFrom) succs(b *ssa.BasicBlock) bool` ignores other than the first BasicBlock in a recursive loop.
It causes an unexpected pass through when the function's signature has multiple return values.