### PR TITLE
Fix: lookup itself and allow vendored

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -7,9 +7,9 @@ import (
 
 // RemoVendor removes vendoring infomation from import path.
 func RemoveVendor(path string) string {
-	i := strings.Index(path, "vendor")
+	i := strings.Index(path, "vendor/")
 	if i >= 0 {
-		return path[i+len("vendor")+1:]
+		return path[i+len("vendor/"):]
 	}
 	return path
 }

--- a/pkg.go
+++ b/pkg.go
@@ -3,13 +3,15 @@ package analysisutil
 import (
 	"go/types"
 	"strings"
+	"path/filepath"
 )
 
 // RemoVendor removes vendoring infomation from import path.
 func RemoveVendor(path string) string {
-	i := strings.Index(path, "vendor/")
+	unixVendorPath := "vendor/"
+	i := strings.Index(path, filepath.FromSlash(unixVendorPath))
 	if i >= 0 {
-		return path[i+len("vendor/"):]
+		return path[i+len(unixVendorPath):]
 	}
 	return path
 }

--- a/pkg.go
+++ b/pkg.go
@@ -3,15 +3,13 @@ package analysisutil
 import (
 	"go/types"
 	"strings"
-	"path/filepath"
 )
 
 // RemoVendor removes vendoring infomation from import path.
 func RemoveVendor(path string) string {
-	unixVendorPath := "vendor/"
-	i := strings.Index(path, filepath.FromSlash(unixVendorPath))
+	i := strings.Index(path, "vendor/")
 	if i >= 0 {
-		return path[i+len(unixVendorPath):]
+		return path[i+len("vendor/"):]
 	}
 	return path
 }

--- a/testdata/src/objectof/main.go
+++ b/testdata/src/objectof/main.go
@@ -1,0 +1,15 @@
+package objectof
+
+import (
+	"fmt"
+	"io"
+	"vendored"
+)
+
+type A int
+var EOF = io.EOF
+var _ = vendored.EOF
+
+func main() {
+	fmt.Println(EOF)
+}

--- a/testdata/src/objectof/vendor/vendored/vendored.go
+++ b/testdata/src/objectof/vendor/vendored/vendored.go
@@ -1,0 +1,5 @@
+package vendored
+
+import "io"
+
+var EOF = io.EOF

--- a/types.go
+++ b/types.go
@@ -20,6 +20,9 @@ func ObjectOf(pass *analysis.Pass, pkg, name string) types.Object {
 	if obj != nil {
 		return obj
 	}
+	if RemoveVendor(pass.Pkg.Name()) != RemoveVendor(pkg) {
+		return nil
+	}
 	return pass.Pkg.Scope().Lookup(name)
 }
 

--- a/types.go
+++ b/types.go
@@ -16,7 +16,11 @@ func ImplementsError(t types.Type) bool {
 
 // ObjectOf returns types.Object by given name in the package.
 func ObjectOf(pass *analysis.Pass, pkg, name string) types.Object {
-	return LookupFromImports(pass.Pkg.Imports(), pkg, name)
+	obj := LookupFromImports(pass.Pkg.Imports(), pkg, name)
+	if obj != nil {
+		return obj
+	}
+	return pass.Pkg.Scope().Lookup(name)
 }
 
 // TypeOf returns types.Type by given name in the package.

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,59 @@
+package analysisutil_test
+
+import (
+	"go/token"
+	"log"
+	"testing"
+
+	"github.com/gostaticanalysis/analysisutil"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+const pkg = "objectof"
+
+var analyzer = &analysis.Analyzer{
+	Name: "test_types",
+	Run:  run_test_types,
+	Requires: []*analysis.Analyzer{
+		buildssa.Analyzer,
+	},
+}
+
+func Test_Types(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, analyzer, pkg)
+}
+
+func run_test_types(pass *analysis.Pass) (interface{}, error) {
+	tests := []struct {
+		path, name string
+		found      bool
+	}{
+		{"fmt", "Println", true},
+		{pkg, "A", true},
+		{pkg, "EOF", true},
+		{"io", "EOF", true},
+		{"reflect", "Kind", false},
+		{"a", "ok", false},
+		{"vendored", "EOF", true},
+		{"c", "EOF", false},
+	}
+
+	log.Println(analysisutil.LookupFromImports(pass.Pkg.Imports(), "vendored", "EOF"))
+
+	for _, tt := range tests {
+		tt := tt
+		obj := analysisutil.ObjectOf(pass, tt.path, tt.name)
+
+		if obj == nil && tt.found {
+			pass.Reportf(token.NoPos, "objectof could not find %s.%s", tt.path, tt.name)
+		}
+		if obj != nil && !tt.found {
+			pass.Reportf(token.NoPos, "objectof found %s.%s, which does not exist", tt.path, tt.name)
+		}
+	}
+
+	return nil, nil
+}

--- a/types_test.go
+++ b/types_test.go
@@ -2,7 +2,6 @@ package analysisutil_test
 
 import (
 	"go/token"
-	"log"
 	"testing"
 
 	"github.com/gostaticanalysis/analysisutil"
@@ -40,8 +39,6 @@ func run_test_types(pass *analysis.Pass) (interface{}, error) {
 		{"vendored", "EOF", true},
 		{"c", "EOF", false},
 	}
-
-	log.Println(analysisutil.LookupFromImports(pass.Pkg.Imports(), "vendored", "EOF"))
 
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
- Add a test for types.go
- Make the `ObjectOf` lookup the package itself
- Fix the bug about RemoveVendor which mis-recognize `vendored` package