### PR TITLE
Check function call even after cycle

### DIFF
--- a/call.go
+++ b/call.go
@@ -43,32 +43,21 @@ func (c *CalledChecker) Func(instr ssa.Instruction, recv ssa.Value, f *types.Fun
 	if recv != nil &&
 		common.Signature().Recv() != nil &&
 		(len(common.Args) == 0 && recv != nil || common.Args[0] != recv &&
-			!isReferrer(recv, common.Args[0])) {
+			!referrer(recv, common.Args[0])) {
 		return false
 	}
 
 	return fn == f
 }
 
-func isReferrer(a, b ssa.Value) bool {
+func referrer(a, b ssa.Value) bool {
+	return isReferrerOf(a, b) || isReferrerOf(b, a)
+}
+
+func isReferrerOf(a, b ssa.Value) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	if a.Referrers() != nil {
-		ars := *a.Referrers()
-
-		for _, ar := range ars {
-			arv, ok := ar.(ssa.Value)
-			if !ok {
-				continue
-			}
-			if arv == b {
-				return true
-			}
-
-		}
-	}
-
 	if b.Referrers() != nil {
 		brs := *b.Referrers()
 

--- a/call.go
+++ b/call.go
@@ -42,11 +42,47 @@ func (c *CalledChecker) Func(instr ssa.Instruction, recv ssa.Value, f *types.Fun
 
 	if recv != nil &&
 		common.Signature().Recv() != nil &&
-		(len(common.Args) == 0 || common.Args[0] != recv) {
+		(len(common.Args) == 0 && recv != nil || common.Args[0] != recv &&
+			!isReferrer(recv, common.Args[0])) {
 		return false
 	}
 
 	return fn == f
+}
+
+func isReferrer(a, b ssa.Value) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Referrers() != nil {
+		ars := *a.Referrers()
+
+		for _, ar := range ars {
+			arv, ok := ar.(ssa.Value)
+			if !ok {
+				continue
+			}
+			if arv == b {
+				return true
+			}
+
+		}
+	}
+
+	if b.Referrers() != nil {
+		brs := *b.Referrers()
+
+		for _, br := range brs {
+			brv, ok := br.(ssa.Value)
+			if !ok {
+				continue
+			}
+			if brv == a {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // From checks whether receiver's method is called in an instruction
@@ -173,7 +209,7 @@ func (c *calledFrom) succs(b *ssa.BasicBlock) bool {
 	}
 
 	if c.done[b] {
-		return false
+		return true
 	}
 	c.done[b] = true
 

--- a/call_test.go
+++ b/call_test.go
@@ -30,9 +30,7 @@ func Test(t *testing.T) {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	st = analysisutil.LookupFromImports([]*types.Package{
-		pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).Pkg.Pkg,
-	}, "b", "st").Type().(*types.Named)
+	st = analysisutil.TypeOf(pass, "b", "*st")
 	close = analysisutil.MethodOf(st, "b.close")
 	doSomethingAndReturnSt = analysisutil.MethodOf(st, "b.doSomethingAndReturnSt")
 
@@ -45,7 +43,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				}
 				called, ok := analysisutil.CalledFrom(b, i, st, close)
 				if !(called && ok) {
-					pass.Reportf(instr.Pos(), "close should be called after calling doSomething")
+					pass.Reportf(instr.Pos(), close.Name()+" should be called after calling "+doSomethingAndReturnSt.Name())
 				}
 			}
 		}

--- a/testdata/src/b/main.go
+++ b/testdata/src/b/main.go
@@ -28,3 +28,11 @@ func test3() {
 	}
 	s.close()
 }
+
+func test4() {
+	var s = &st{}
+	s.doSomethingAndReturnSt() // want `close should be called after calling doSomethingAndReturnSt`
+	for i := 0; i < 3; i++ {
+		// simple loop to check if the analyzer properly stops and lints in cycle.
+	}
+}

--- a/testdata/src/b/main.go
+++ b/testdata/src/b/main.go
@@ -4,11 +4,11 @@ type st struct {
 	o bool
 }
 
-func (s st) doSomethingAndReturnSt() st {
+func (s *st) doSomethingAndReturnSt() *st {
 	return s
 }
 
-func (s st) close() {}
+func (s *st) close() {}
 
 func test1() {
 	var s st
@@ -18,4 +18,13 @@ func test1() {
 func test2() {
 	var s st
 	s.doSomethingAndReturnSt().close()
+}
+
+func test3() {
+	var s = &st{}
+	s.doSomethingAndReturnSt()
+	for i := 0; i < 3; i++ {
+		// simple loop to check if the analyzer properly stops and lints in cycle.
+	}
+	s.close()
 }


### PR DESCRIPTION
Add test that reproduces the case in which the call after a cycle is not checked and make the analyzer check it.
This pull request cause the failure of a test because the function `ObjectOf` in types.go can't get the object in the package itself (not imported one), but it will succeed after #9 is merged.