### PR TITLE
Add type check for #18

### DIFF
--- a/call.go
+++ b/call.go
@@ -91,7 +91,18 @@ func (c *CalledChecker) From(b *ssa.BasicBlock, i int, receiver types.Type, meth
 	}
 
 	if !identical(v.Type(), receiver) {
-		return false, false
+		t, ok := v.Type().(*types.Tuple)
+		if !ok {
+			return false, false
+		}
+		for j := 0; j < t.Len(); j++ {
+			if identical(t.At(j).Type(), receiver) {
+				break
+			}
+			if j == t.Len()-1 {
+				return false, false
+			}
+		}
 	}
 
 	from := &calledFrom{recv: v, fs: methods, ignore: c.Ignore}

--- a/call.go
+++ b/call.go
@@ -90,19 +90,8 @@ func (c *CalledChecker) From(b *ssa.BasicBlock, i int, receiver types.Type, meth
 		return false, false
 	}
 
-	if !identical(v.Type(), receiver) {
-		t, ok := v.Type().(*types.Tuple)
-		if !ok {
-			return false, false
-		}
-		for j := 0; j < t.Len(); j++ {
-			if identical(t.At(j).Type(), receiver) {
-				break
-			}
-			if j == t.Len()-1 {
-				return false, false
-			}
-		}
+	if !identical(v.Type(), receiver) && !identicalToTupleChild(v.Type(), receiver) {
+		return false, false
 	}
 
 	from := &calledFrom{recv: v, fs: methods, ignore: c.Ignore}

--- a/types.go
+++ b/types.go
@@ -78,6 +78,19 @@ func identical(x, y types.Type) (ret bool) {
 	return types.Identical(x, y)
 }
 
+func identicalToTupleChild(typ types.Type, receiver types.Type) bool {
+	t, ok := typ.(*types.Tuple)
+	if !ok {
+		return false
+	}
+	for i := 0; i < t.Len(); i++ {
+		if identical(t.At(i).Type(), receiver) {
+			return true
+		}
+	}
+	return false
+}
+
 // Interfaces returns a map of interfaces which are declared in the package.
 func Interfaces(pkg *types.Package) map[string]*types.Interface {
 	ifs := map[string]*types.Interface{}


### PR DESCRIPTION
#18 

If `v.Type()` is `*types.Tuple`, check child values of `*types.Tuple`