### PR TITLE
return nil when pointer types could not found

### DIFF
--- a/types.go
+++ b/types.go
@@ -37,7 +37,7 @@ func TypeOf(pass *analysis.Pass, pkg, name string) types.Type {
 		obj := TypeOf(pass, pkg, name[1:])
 		if obj == nil {
 			return nil
-		}else{
+		} else {
 			return types.NewPointer(obj)
 		}
 	}

--- a/types.go
+++ b/types.go
@@ -34,7 +34,12 @@ func TypeOf(pass *analysis.Pass, pkg, name string) types.Type {
 	}
 
 	if name[0] == '*' {
-		return types.NewPointer(TypeOf(pass, pkg, name[1:]))
+		obj := TypeOf(pass, pkg, name[1:])
+		if obj == nil {
+			return nil
+		}else{
+			return types.NewPointer(obj)
+		}
 	}
 
 	obj := ObjectOf(pass, pkg, name)

--- a/types.go
+++ b/types.go
@@ -37,9 +37,8 @@ func TypeOf(pass *analysis.Pass, pkg, name string) types.Type {
 		obj := TypeOf(pass, pkg, name[1:])
 		if obj == nil {
 			return nil
-		} else {
-			return types.NewPointer(obj)
 		}
+		return types.NewPointer(obj)
 	}
 
 	obj := ObjectOf(pass, pkg, name)

--- a/types_test.go
+++ b/types_test.go
@@ -38,7 +38,7 @@ func run_test_types(pass *analysis.Pass) (interface{}, error) {
 		{"a", "ok", false},
 		{"vendored", "EOF", true},
 		{"c", "EOF", false},
-		{"database/sql","*DB",false},
+		{"database/sql", "*DB", false},
 	}
 
 	for _, tt := range tests {

--- a/types_test.go
+++ b/types_test.go
@@ -38,6 +38,7 @@ func run_test_types(pass *analysis.Pass) (interface{}, error) {
 		{"a", "ok", false},
 		{"vendored", "EOF", true},
 		{"c", "EOF", false},
+		{"database/sql","*DB",false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# 問題
パッケージをインポートしていない場合にポインタを探すよう指定するとnilポインタが返ってきてしまっていました。

例
```
typ := analysisutil.TypeOf(pass, "database/sql", "*DB")
-> *<nil>
```
# 修正
事前に型が存在するかをチェックするようにしました