### PR TITLE
Fix UnOp

### DIFF
--- a/ssa.go
+++ b/ssa.go
@@ -109,6 +109,12 @@ func usedInInstr(v ssa.Value, instr ssa.Instruction) ssa.Instruction {
 			}
 		}
 	}
+
+	switch v := v.(type) {
+	case *ssa.UnOp:
+		return usedInInstr(v.X, instr)
+	}
+
 	return nil
 }
 

--- a/testdata/src/used/used.go
+++ b/testdata/src/used/used.go
@@ -46,3 +46,9 @@ func f8(v interface{}) { // want "used"
 		println(v)
 	}()
 }
+
+func f9(v interface{}) { // want "used"
+	func(v interface{}) { // want "used"
+		println(v)
+	}(v)
+}


### PR DESCRIPTION
* Fix Used: if `ssa.Value` is `*ssa.UnOp`, `Used` try to check `ssa.UnOp.X`.